### PR TITLE
Fix Nametags not showing for Slapper Entitys & Humans

### DIFF
--- a/Slapper/src/slapper/entities/SlapperEntity.php
+++ b/Slapper/src/slapper/entities/SlapperEntity.php
@@ -109,7 +109,7 @@ class SlapperEntity extends Entity {
         $pk->pitch = 0;
         $pk->item = Item::get(0);
         $pk->metadata = [
-            self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_INVISIBLE) | (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) | 1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) | (1 << self::DATA_FLAG_NO_AI))],
+            self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_INVISIBLE) | (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) | (1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) | (1 << self::DATA_FLAG_NO_AI))],
             self::DATA_NAMETAG => [self::DATA_TYPE_STRING, $name],
             self::DATA_LEAD_HOLDER_EID => [self::DATA_TYPE_LONG, -1]
         ];

--- a/Slapper/src/slapper/entities/SlapperEntity.php
+++ b/Slapper/src/slapper/entities/SlapperEntity.php
@@ -109,7 +109,7 @@ class SlapperEntity extends Entity {
         $pk->pitch = 0;
         $pk->item = Item::get(0);
         $pk->metadata = [
-            self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_INVISIBLE) | (1 << self::DATA_FLAG_NO_AI))],
+            self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_INVISIBLE) | (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) | 1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) | (1 << self::DATA_FLAG_NO_AI))],
             self::DATA_NAMETAG => [self::DATA_TYPE_STRING, $name],
             self::DATA_LEAD_HOLDER_EID => [self::DATA_TYPE_LONG, -1]
         ];

--- a/Slapper/src/slapper/entities/SlapperHuman.php
+++ b/Slapper/src/slapper/entities/SlapperHuman.php
@@ -27,7 +27,7 @@ class SlapperHuman extends Human {
             $pk->pitch = $this->pitch;
             $pk->item = $this->getInventory()->getItemInHand();
             $pk->metadata = [
-                self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_NO_AI) | (1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) | ($this->isNameTagVisible() ? (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) : 0))],
+                self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_NO_AI) | ($this->isNameTagVisible() ? (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) | (1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) : 0))],
                 self::DATA_NAMETAG => [self::DATA_TYPE_STRING, str_ireplace("{name}", $player->getName(), str_ireplace("{display_name}", $player->getDisplayName(), $player->hasPermission("slapper.seeId") ? $this->getNameTag() . "\n" . \pocketmine\utils\TextFormat::GREEN . "Entity ID: " . $entityId : $this->getNameTag()))],
                 self::DATA_LEAD_HOLDER_EID => [self::DATA_TYPE_LONG, -1]
             ];

--- a/Slapper/src/slapper/entities/SlapperHuman.php
+++ b/Slapper/src/slapper/entities/SlapperHuman.php
@@ -27,7 +27,7 @@ class SlapperHuman extends Human {
             $pk->pitch = $this->pitch;
             $pk->item = $this->getInventory()->getItemInHand();
             $pk->metadata = [
-                self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_NO_AI) | ($this->isNameTagVisible() ? (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) : 0))],
+                self::DATA_FLAGS => [self::DATA_TYPE_LONG, ((1 << self::DATA_FLAG_NO_AI) | (1 << self::DATA_FLAG_ALWAYS_SHOW_NAMETAG) | ($this->isNameTagVisible() ? (1 << self::DATA_FLAG_CAN_SHOW_NAMETAG) : 0))],
                 self::DATA_NAMETAG => [self::DATA_TYPE_STRING, str_ireplace("{name}", $player->getName(), str_ireplace("{display_name}", $player->getDisplayName(), $player->hasPermission("slapper.seeId") ? $this->getNameTag() . "\n" . \pocketmine\utils\TextFormat::GREEN . "Entity ID: " . $entityId : $this->getNameTag()))],
                 self::DATA_LEAD_HOLDER_EID => [self::DATA_TYPE_LONG, -1]
             ];


### PR DESCRIPTION
This fixes the issue with the Nametags not showing above Slapper Humans and Entitys unless very close. This has been tested and works perfectly for the Entitys, the humans you seem to have to change levels then go back to the original for them to appear, but after that they work perfectly.